### PR TITLE
Install composer from docker image

### DIFF
--- a/php/7.1-apache/Dockerfile
+++ b/php/7.1-apache/Dockerfile
@@ -20,7 +20,7 @@ RUN pecl install mongodb \
     pcntl \
     zip
 
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 
 # Apache configuration
 ENV APACHE_DOCUMENT_ROOT /var/www/html/public


### PR DESCRIPTION
There is a better way to install composer in docker images as recommended by composer's maintainer

https://github.com/docker-library/php/issues/344#issuecomment-364843883