### PR TITLE
Bound xdebug to version 2.9.8 on PHP 7.1

### DIFF
--- a/php/7.1-apache/Dockerfile
+++ b/php/7.1-apache/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update -qq \
   && apt-get clean
 
 RUN pecl install mongodb \
-  && pecl install xdebug \
+  && pecl install -f xdebug-2.9.8 \
   && docker-php-ext-enable \
     mongodb \
   && docker-php-ext-install \

--- a/php/7.1-fpm-nginx/Dockerfile
+++ b/php/7.1-fpm-nginx/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update -qq \
  && apt-get clean
 
 RUN pecl install mongodb \
-  && pecl install xdebug \
+  && pecl install -f xdebug-2.9.8 \
   && docker-php-ext-enable \
     mongodb \
   && docker-php-ext-install \

--- a/php/7.1-fpm/Dockerfile
+++ b/php/7.1-fpm/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update -qq \
  && apt-get clean
 
 RUN pecl install mongodb \
-  && pecl install xdebug \
+  && pecl install -f xdebug-2.9.8 \
   && docker-php-ext-enable \
     mongodb \
   && docker-php-ext-install \

--- a/php/7.1/Dockerfile
+++ b/php/7.1/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update -qq \
   && apt-get clean
 
 RUN pecl install mongodb \
-  && pecl install xdebug \
+  && pecl install -f xdebug-2.9.8 \
   && docker-php-ext-enable \
     mongodb \
   && docker-php-ext-install \


### PR DESCRIPTION
Version >=3 is no longer compatible with PHP 7.1