### PR TITLE
task(challenge/v2): set xdebug to coverage

### DIFF
--- a/php/backend-challenge-v2/custom.ini
+++ b/php/backend-challenge-v2/custom.ini
@@ -1,3 +1,4 @@
 error_reporting=E_ALL
 memory_limit=-1
 max_execution_time=60
+xdebug.mode=coverage


### PR DESCRIPTION
Alterado a configuração do PHP através do custom.ini, setando o valod do `xdebug` para `coverage`, de forma a permitir a execução do `phpunit` em suas versões mais rescentes.

![image](https://user-images.githubusercontent.com/10175963/108083367-bf5ae880-7051-11eb-89b4-b084de51aada.png)